### PR TITLE
Allow for specifying datasets instead of pools

### DIFF
--- a/ioztat
+++ b/ioztat
@@ -29,6 +29,7 @@
 
 import argparse
 import os
+import re
 import sys
 import time
 
@@ -150,12 +151,13 @@ def formatName(name):
         return name
 
 parser = argparse.ArgumentParser(description='iostat for ZFS datasets')
-parser.add_argument('pool', type=str, nargs='+', help='ZFS pool')
+parser.add_argument('dataset', type=str, nargs='+', help='ZFS dataset')
 parser.add_argument('-s', dest='sort', default='name2', type=str, help='Sort by: name / wps / wMBps / rps / rMBps')
 parser.add_argument('-i', dest='interval', default=1, type=float, help='Time between each report')
 parser.add_argument('-c', dest='count', type=int, help='Number of reports generated')
 parser.add_argument('-y', dest='skipsummary', default=False, action='store_true', help='Skip the initial "summary" report')
 parser.add_argument('-b', dest='binaryprefix', default=False, action='store_true', help='Use binary (power-of-two) prefixes')
+parser.add_argument('-n', dest='nonrecursive', default=False, action='store_true', help='Do not recurse into parent datasets')
 args = parser.parse_args()
 
 if (args.skipsummary == True) and (args.count):
@@ -165,13 +167,23 @@ prefixmultiplier = 1.0e3
 if args.binaryprefix:
     prefixmultiplier = 2.0**10
 
+pools = {dataset.split('/')[0] for dataset in args.dataset}
+if args.nonrecursive:
+    # Make each match exact.
+    dataset_pattern = re.compile("|".join(map(lambda ds: "\A" + re.escape(ds) + "\Z", sorted(args.dataset))))
+else:
+    # Accept either an exact match or one with an additional component
+    dataset_pattern = re.compile("|".join(map(lambda ds: "\A" + re.escape(ds) + "(?:\Z|/[^/]+)", sorted(args.dataset))))
+
 try:
     prevdatasets = {}
     index = 0
     while(True):
         datasets = {}
-        for pool in args.pool:
+        for pool in pools:
             datasets.update(parseDatasets(pool))
+
+        datasets = {name: dataset for name, dataset in datasets.items() if dataset_pattern.match(name)}
 
         diff = calcDiff(prevdatasets, datasets)
         if index == 0:


### PR DESCRIPTION
Also add a -n flag for non-recursive operation, showing only the
specific datasets requested.

This is an alternative to #10 which supports globbing.