### PR TITLE
Add a -T timestamp flag with u and d options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For the most part, `ioztat` behaves the same way that the system standard `iosta
 
 ````
 usage: ioztat [-b] [-c COUNT] [-h] [-i INTERVAL] [-n] [-o] [-P | -p] [-s {name,rps,wps,rMBps,wMBps}]
-              [-y] [-V] [-z]
+              [-T {u,d}] [-y] [-V] [-z]
               [dataset [dataset ...]]
 
 iostat for ZFS datasets
@@ -46,6 +46,7 @@ optional arguments:
   -p                    display dataset names as an abbreviated tree
   -s {name,rps,wps,rMBps,wMBps}
                         sort by the specified field
+  -T {u,d}              prefix each report with a Unix timestamp or formatted date
   -y                    skip the initial "summary" report
   -V, --version         show program's version number and exit
   -z                    suppress datasets with zero activity

--- a/ioztat
+++ b/ioztat
@@ -198,6 +198,7 @@ group = parser.add_mutually_exclusive_group()
 group.add_argument('-P', dest='fullname', default=None, action='store_true', help='display dataset names on a single line')
 group.add_argument('-p', dest='fullname', default=None, action='store_false', help='display dataset names as an abbreviated tree')
 parser.add_argument('-s', dest='sort', default='name', choices=sorts.keys(), help='sort by the specified field')
+parser.add_argument('-T', dest='timestamp', default=False, choices=['u', 'd'], help='prefix each report with a Unix timestamp or formatted date')
 parser.add_argument('-y', dest='skipsummary', default=False, action='store_true', help='skip the initial "summary" report')
 parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + PROGRAM_VERSION)
 parser.add_argument('-z', dest='nonzero', default=False, action='store_true', help='suppress datasets with zero activity')
@@ -239,6 +240,11 @@ try:
         if args.overwrite:
             # Clear the screen and move the cursor to the upper-left
             print("\033[2J\033[1;1H", end = '')
+
+        if args.timestamp == 'u':
+            print(int(time.time()))
+        elif args.timestamp == 'd':
+            print(time.strftime('%c'))
 
         print('{:40s} {:>10s} {:>10s} {:>10s} {:>10s} {:>10s} {:>10s}'
             .format('dataset', 'w/s', 'wMB/s', 'r/s', 'rMB/s', 'wareq-sz', 'rareq-sz'))


### PR DESCRIPTION
This mirrors zpool iostat's -T flag, prefixing each report with either a
numeric Unix timestamp or a formatted datetime.