### PR TITLE
Do not filter empty diffs in overwrite mode

### DIFF
--- a/ioztat
+++ b/ioztat
@@ -227,7 +227,8 @@ if args.skipsummary or args.count:
     import itertools
     diff_loop = itertools.islice(diff_loop, int(args.skipsummary), args.count + int(args.skipsummary))
 
-diff_loop = filter(None, diff_loop)
+if not args.overwrite:
+    diff_loop = filter(None, diff_loop)
 
 try:
     for diff in diff_loop:


### PR DESCRIPTION
In normal output, there are arguably reasonable hints that iterations
are being skipped, since historic context hangs around.  This is
obviously missing in overwrite mode.

Resolve this by allowing it to display nothing.