### PR TITLE
Make numeric precision variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,24 @@ This sample output shows activity which has taken place in the most recent secon
 
 ````
 root@redacted-prod0:~# ioztat -y -c1 ssd
-                    operations      bandwidth         opsize
-dataset             read   write    read   write    read   write
-----------------  ------  ------  ------  ------  ------  ------
-ssd                    0       0       0       0       0       0
-  images               0       0       0       0       0       0
-    DC1                4      18   49.0K   98.0K   12.5K    5.6K
-    DC2                0      22       0  137.3K       0    6.4K
-    QB                 0       2       0    9.8K       0    5.0K
-    SAP-TC             0       3       0   19.6K       0    6.7K
-    SAP4-WIN2019       0       3       0   49.0K       0   16.7K
-    nagios             0       0       0       0       0       0
-    qemu               0       0       0       0       0       0
-      autostart        0       0       0       0       0       0
-  iso                  0       0       0       0       0       0
-  unsnapped            0       0       0       0       0       0
-    rp9                0       0       0       0       0       0
+                   operations    bandwidth       opsize
+dataset            read  write   read  write   read  write
+----------------  -----  -----  -----  -----  -----  -----
+ssd                   0      0      0      0      0      0
+  images              0      0      0      0      0      0
+    DC1               4     18  49.0K  98.0K  12.5K  5.56K
+    DC2               0     22      0   137K      0  6.36K
+    QB                0      2      0  9.80K      0  5.00K
+    SAP-TC            0      3      0  19.6K      0  6.67K
+    SAP4-WIN2019      0      3      0  49.0K      0  16.7K
+    nagios            0      0      0      0      0      0
+    qemu              0      0      0      0      0      0
+      autostart       0      0      0      0      0      0
+  iso                 0      0      0      0      0      0
+  unsnapped           0      0      0      0      0      0
+    rp9               0      0      0      0      0      0
+----------------  -----  -----  -----  -----  -----  -----
+
 ````
 
 For the most part, `ioztat` behaves the same way that the system standard `iostat` tool does, with similar arguments.

--- a/ioztat
+++ b/ioztat
@@ -271,38 +271,35 @@ class ColumnGroupFormatter(ColumnFormatter):
 
 SIZE_PREFIX = ('', 'K', 'M', 'G', 'T', 'P', 'E')
 SIZE_PREFIX_MAX = len(SIZE_PREFIX) - 1
-THRESHOLD_BY_PRECISION_1000 = [1000 - x for x in (0.5, 0.05, 0.005)]
-THRESHOLD_BY_PRECISION_1024 = [1024 - x for x in (0.5, 0.05, 0.005)]
-
+POWERS_1000 = [pow(1000, i) for i in range(len(SIZE_PREFIX))]
+POWERS_1024 = [pow(1024, i) for i in range(len(SIZE_PREFIX))]
+FORMATS_BY_PRECISION = ['{:.2f}{}', '{:.1f}{}', '{:.0f}{}']
 def number_to_human(num, length, binary = False):
     """Format a number to a SI decimal or binary string representation that
     should fit within length bytes"""
     if binary:
-        div = 1024
-        thresholds = THRESHOLD_BY_PRECISION_1024
+        divisor = 1024
+        powers = POWERS_1024
     else:
-        div = 1000
-        thresholds = THRESHOLD_BY_PRECISION_1000
+        divisor = 1000
+        powers = POWERS_1000
 
-    if num < div:
-        return str(round(num))
-
+    n = num
     index = 0
-    while num > div and index < SIZE_PREFIX_MAX:
-        num /= div
+    while n >= divisor and index <= SIZE_PREFIX_MAX:
+        n /= divisor
         index += 1
 
-    # Calculate the number of decimal places we're about to print, and check
-    # we shouldn't round up to the next prefix instead. e.g:
-    # 999950 (1MB-50) becomes 1.00M instead of 1000.0K
-    # 1073217536 (1GiB-512KiB) becomes 1.00G instead of 1024M
-    precision = min(2, max(0, length - (len(str(round(num))) + 2)))
-    if num >= thresholds[precision] and index != SIZE_PREFIX_MAX:
-        num /= div
-        index += 1
-        precision = min(2, max(0, length - (len(str(round(num))) + 2)))
+    u = SIZE_PREFIX[index]
 
-    return "{:.{width}f}{}".format(num, SIZE_PREFIX[index], width=precision)
+    if index == 0 or num % powers[index] == 0:
+        return str(int(n)) + u
+
+    for fmt in FORMATS_BY_PRECISION:
+        ret = fmt.format(n, u)
+        if len(ret) <= length:
+            return ret
+    return ret
 
 def format_dataset(path, limit, ellipsis = '+'):
     """Truncate a dataset name to a limit"""

--- a/ioztat
+++ b/ioztat
@@ -30,6 +30,7 @@
 PROGRAM_VERSION = '2.0.0-dev'
 
 import argparse
+import math
 import os
 import re
 import shutil
@@ -269,26 +270,40 @@ class ColumnGroupFormatter(ColumnFormatter):
 ################################################################################
 # General formatting
 
-# A more complete take on this is available here
-# https://stackoverflow.com/questions/12523586/python-format-size-application-converting-b-to-kb-mb-gb-tb/63839503#63839503
-SIZE_PREFIX = ['K', 'M', 'G', 'T', 'P', 'E']
+SIZE_PREFIX = ('', 'K', 'M', 'G', 'T', 'P', 'E')
 SIZE_PREFIX_MAX = len(SIZE_PREFIX) - 1
-def bytes_to_human(num, binary=False):
-    div = 1024 if binary else 1000
-    step = div - 0.05
+THRESHOLD_BY_PRECISION_1000 = [1000 - x for x in (0.5, 0.05, 0.005)]
+THRESHOLD_BY_PRECISION_1024 = [1024 - x for x in (0.5, 0.05, 0.005)]
+
+def number_to_human(num, length, binary = False):
+    """Format a number to a SI decimal or binary string representation that
+    should fit within length bytes"""
+    if binary:
+        div = 1024
+        thresholds = THRESHOLD_BY_PRECISION_1024
+    else:
+        div = 1000
+        thresholds = THRESHOLD_BY_PRECISION_1000
 
     if num < div:
-        return '{:.0f}'.format(num)
+        return str(round(num))
 
-    num /= div
+    index = 0
+    while num > div and index < SIZE_PREFIX_MAX:
+        num /= div
+        index += 1
 
-    for p in range(len(SIZE_PREFIX)):
-        if num < step:
-            break
-        if p < SIZE_PREFIX_MAX:
-            num /= div
+    # Calculate the number of decimal places we're about to print, and check
+    # we shouldn't round up to the next prefix instead. e.g:
+    # 999950 (1MB-50) becomes 1.00M instead of 1000.0K
+    # 1073217536 (1GiB-512KiB) becomes 1.00G instead of 1024M
+    precision = min(2, max(0, length - (math.ceil(math.log10(num)) + 2)))
+    if num >= thresholds[precision] and index != SIZE_PREFIX_MAX:
+        num /= div
+        index += 1
+        precision = min(2, max(0, length - (math.ceil(math.log10(num)) + 2)))
 
-    return '{:.1f}{}'.format(num, SIZE_PREFIX[p])
+    return "{:.{width}f}{}".format(num, SIZE_PREFIX[index], width=precision)
 
 def format_dataset(path, limit, ellipsis = '+'):
     """Truncate a dataset name to a limit"""
@@ -409,10 +424,10 @@ else:
     column_separator = '  '
     name_just = str.ljust
     num_just = str.rjust
-    field_width = 11 if args.exact else 6
+    field_width = 11 if args.exact else 5
 
-format_iops = round if args.exact else lambda num: bytes_to_human(num, False)
-format_bytes = round if args.exact else lambda num: bytes_to_human(num, args.binaryprefix)
+format_iops = round if args.exact else lambda num: number_to_human(num, field_width)
+format_bytes = round if args.exact else lambda num: number_to_human(num, field_width, args.binaryprefix)
 
 formatter = ColumnFormatter(column_separator = column_separator, row_separator = '-')
 formatter.add_column('dataset', just=name_just)

--- a/ioztat
+++ b/ioztat
@@ -30,7 +30,6 @@
 PROGRAM_VERSION = '2.0.0-dev'
 
 import argparse
-import math
 import os
 import re
 import shutil
@@ -297,11 +296,11 @@ def number_to_human(num, length, binary = False):
     # we shouldn't round up to the next prefix instead. e.g:
     # 999950 (1MB-50) becomes 1.00M instead of 1000.0K
     # 1073217536 (1GiB-512KiB) becomes 1.00G instead of 1024M
-    precision = min(2, max(0, length - (math.ceil(math.log10(num)) + 2)))
+    precision = min(2, max(0, length - (len(str(round(num))) + 2)))
     if num >= thresholds[precision] and index != SIZE_PREFIX_MAX:
         num /= div
         index += 1
-        precision = min(2, max(0, length - (math.ceil(math.log10(num)) + 2)))
+        precision = min(2, max(0, length - (len(str(round(num))) + 2)))
 
     return "{:.{width}f}{}".format(num, SIZE_PREFIX[index], width=precision)
 


### PR DESCRIPTION
Matching ZFS number formatting behaviour, use between 0 and 2 decimal
places according to available space, and further reduce the column
size to again match zpool-iostat and make more room for dataset names.

This includes the careful rounding behaviour of the previous
implementation, which I believe ZFS lacks.