### PR TITLE
Add [interval [count]] positional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The statistics offered are read and write operations per second, read and write 
 This sample output shows activity which has taken place in the most recent second, on a the `ssd` zpool of a ZFS virtualization host:
 
 ````
-root@redacted-prod0:~# ioztat -y -c1 ssd
+root@redacted-prod0:~# ioztat -y ssd
                    operations    throughput      opsize
 dataset            read  write   read  write   read  write
 ----------------  -----  -----  -----  -----  -----  -----
@@ -24,7 +24,6 @@ ssd                   0      0      0      0      0      0
   unsnapped           0      0      0      0      0      0
     rp9               0      0      0      0      0      0
 ----------------  -----  -----  -----  -----  -----  -----
-
 ````
 
 For the most part, `ioztat` behaves the same way that the system standard `iostat` tool does, with similar arguments.
@@ -32,12 +31,13 @@ For the most part, `ioztat` behaves the same way that the system standard `iosta
 ````
 usage: ioztat [-c COUNT] [-D] [-e] [-H] [-h] [-i INTERVAL] [-N] [-n] [-o] [-P | -p]
               [-s {name,operations,reads,writes,throughput,nread,nwritten}] [-T {u,d}] [-V] [-y] [-z]
-              [dataset [dataset ...]]
+              [dataset [dataset ...]] [interval [count]]
 
 iostat for ZFS datasets
 
 positional arguments:
   dataset               ZFS dataset
+  interval [count]      seconds between reports and number of reports
 
 optional arguments:
   -c COUNT              number of reports generated
@@ -59,6 +59,8 @@ optional arguments:
   -z                    suppress datasets with zero activity
   ````
 
-Without arguments, `ioztat` first prints a summary record showing activity for each mounted dataset since the most recent system boot, then prints a new record showing the most recent activity once per second. The `-i` argument can be used to change the report interval, and the `-c` argument can be used to limit `ioztat` to a certain number of intervals before exiting.
+Without arguments, `ioztat` prints a summary record showing activity for each mounted dataset since the most recent system boot and exits.
 
-For a continually-updated, easy to read summary of pool activity, the `-o` argument will produce output similar to that of GNU watch.
+With an optional interval, `ioztat` will repeat reports until interrupted, or up to a specified count.  If only a count is specified, the interval defaults to one second.  Both interval and count can be specified with `-i` and `-c` or as positional arguments at the very end of the argument list.
+
+For a continually-updated, easy to read summary of pool activity, the `-o` argument with an interval will produce output similar to that of GNU watch.

--- a/ioztat
+++ b/ioztat
@@ -375,7 +375,7 @@ for name, aliases in SORT_ALIAS.items():
 # Keep this ordered alphabetically
 parser = argparse.ArgumentParser(description='iostat for ZFS datasets', add_help=False)
 parser.add_argument('dataset', type=str, nargs='*', help='ZFS dataset')
-parser.add_argument('interval [count]', nargs='?',
+parser.add_argument(argparse.SUPPRESS, metavar='interval [count]', nargs='?',
                           help='seconds between reports and number of reports')
 parser.add_argument('-c', dest='count', type=int,
                           help='number of reports generated')

--- a/ioztat
+++ b/ioztat
@@ -185,12 +185,10 @@ def delay_iter(it, interval):
         time.sleep(interval)
 
 def skip_iter(it, count):
-    """Skip count iterations of the iterator before yielding"""
+    """Skip count iterations of the iterator"""
     for _ in range(count):
         next(it)
-
-    for x in it:
-        yield x
+    return it
 
 def take_iter(it, count):
     """Yield at most count items from iterator"""

--- a/ioztat
+++ b/ioztat
@@ -30,6 +30,7 @@
 PROGRAM_VERSION = '2.0.0-dev'
 
 import argparse
+import math
 import os
 import re
 import shutil
@@ -357,6 +358,8 @@ for name, aliases in SORT_ALIAS.items():
 # Keep this ordered alphabetically
 parser = argparse.ArgumentParser(description='iostat for ZFS datasets', add_help=False)
 parser.add_argument('dataset', type=str, nargs='*', help='ZFS dataset')
+parser.add_argument('interval [count]', nargs='?',
+                          help='seconds between reports and number of reports')
 parser.add_argument('-c', dest='count', type=int,
                           help='number of reports generated')
 parser.add_argument('-D', dest='decimal', action='store_true',
@@ -367,7 +370,7 @@ parser.add_argument('-H', dest='scripted', action='store_true',
                           help='scripted mode, skip headers and tab-separate')
 parser.add_argument('-h', '--help', action='help',
                           help='show this help message and exit')
-parser.add_argument('-i', dest='interval', type=float, default=1,
+parser.add_argument('-i', dest='interval', type=float,
                           help='interval between reports (in seconds)')
 parser.add_argument('-N', dest='headeronce', action='store_true',
                           help='display headers at most once')
@@ -392,6 +395,33 @@ parser.add_argument('-z', dest='nonzero', action='store_true',
                           help='suppress datasets with zero activity')
 
 args = parser.parse_args()
+
+# 123. and .123 but not nan, inf, 1e5, -42, etc
+POSITIVE_FLOAT_PATTERN = re.compile(r'\A(?:\d+\.?\d*|.\d+)\Z')
+def is_positive_float(value):
+    if isinstance(value, str):
+        return POSITIVE_FLOAT_PATTERN.match(value)
+    elif value:
+        return (not math.isnan(value)) and (not math.isinf(value)) and value > 0
+
+if len(args.dataset) > 0 and is_positive_float(args.dataset[-1]):
+    args.interval = float(args.dataset.pop())
+    if len(args.dataset) > 0 and is_positive_float(args.dataset[-1]):
+        args.count = int(round(args.interval))
+        args.interval = int(round(float(args.dataset.pop())))
+
+if args.count is not None and not args.count > 0:
+    parser.error('count must be positive')
+if args.interval is not None and not is_positive_float(args.interval):
+    parser.error('interval must be positive')
+
+# If there's no interval but a count, default to one second
+if args.interval is None and args.count:
+    args.interval = 1.0
+
+if args.count is None and args.interval is None:
+    args.count = 1
+    args.interval = 1.0
 
 # Enable full paths if we're not sorting by name or in nonzero mode, unless otherwise specified
 if args.fullname is None:

--- a/ioztat
+++ b/ioztat
@@ -184,6 +184,20 @@ def delay_iter(it, interval):
         yield item
         time.sleep(interval)
 
+def skip_iter(it, count):
+    """Skip count iterations of the iterator before yielding"""
+    for _ in range(count):
+        next(it)
+
+    for x in it:
+        yield x
+
+def take_iter(it, count):
+    """Yield at most count items from iterator"""
+    while count > 0:
+        yield next(it)
+        count -= 1
+
 ################################################################################
 # Column formatting
 
@@ -470,13 +484,15 @@ formatter.add_column('write', width=field_width, format=format_bytes, just=num_j
 formatter.add_group('opsize', 2)
 
 diff_loop = filter_diff_iter(pools, dataset_pattern, args.nonzero)
-diff_loop = delay_iter(diff_loop, args.interval)
 
-if args.skip or args.count is not None:
-    import itertools
-    if args.count:
-        args.count += args.skip
-    diff_loop = itertools.islice(diff_loop, args.skip, args.count)
+if args.interval:
+    diff_loop = delay_iter(diff_loop, args.interval)
+
+if args.skip:
+    diff_loop = skip_iter(diff_loop, args.skip)
+
+if args.count:
+    diff_loop = take_iter(diff_loop, args.count)
 
 if not args.overwrite:
     diff_loop = filter(None, diff_loop)

--- a/ioztat
+++ b/ioztat
@@ -343,6 +343,11 @@ def print_format_dataset(name, last_path, limit, print=print):
 
     return (indent_dataset_path(cur_path[-1], len(cur_path) - 1, limit), cur_path)
 
+def indented_name_width(path):
+    """Calculate the maximum width of this path as rendered by print_format_dataset"""
+    segments = path.split('/')
+    return (len(segments[0:-1]) * len(PATH_INDENT)) + len(segments[-1])
+
 ################################################################################
 
 SORTS = {
@@ -440,6 +445,8 @@ if args.count is None and args.interval is None:
 if args.fullname is None:
     args.fullname = args.sort != 'name' or args.scripted or args.exact or args.nonzero
 
+calc_name_width = len if args.fullname else indented_name_width
+
 pools = {dataset.split('/')[0] for dataset in args.dataset}
 if args.nonrecursive:
     # Make each match exact.
@@ -447,13 +454,6 @@ if args.nonrecursive:
 else:
     # Accept either an exact match or one with an additional component
     dataset_pattern = re.compile("|".join(("\A" + re.escape(ds) + "(?:\Z|/[^/]+)" for ds in sorted(args.dataset))))
-
-if args.fullname:
-    calc_name_width = len
-else:
-    def calc_name_width(path):
-        segments = path.split('/')
-        return (len(segments[0:-1]) * len(PATH_INDENT)) + len(segments[-1])
 
 if args.scripted:
     column_separator = "\t"

--- a/ioztat
+++ b/ioztat
@@ -408,19 +408,20 @@ parser.add_argument('-z', dest='nonzero', action='store_true',
 
 args = parser.parse_args()
 
-# 123. and .123 but not nan, inf, 1e5, -42, etc
-POSITIVE_FLOAT_PATTERN = re.compile(r'\A(?:\d+\.?\d*|.\d+)\Z')
 def is_positive_float(value):
-    if isinstance(value, str):
-        return POSITIVE_FLOAT_PATTERN.match(value)
-    elif value:
-        return (not math.isnan(value)) and (not math.isinf(value)) and value > 0
+    try:
+        value = float(value)
+        # We want to avoid parsing 'inf' and 'nan', as these are valid pool names
+        # NaN always compares False with another float, so just guard against inf
+        return value > 0.0 and not math.isinf(value)
+    except ValueError:
+        return False
 
 if len(args.dataset) > 0 and is_positive_float(args.dataset[-1]):
     args.interval = float(args.dataset.pop())
     if len(args.dataset) > 0 and is_positive_float(args.dataset[-1]):
         args.count = int(round(args.interval))
-        args.interval = int(round(float(args.dataset.pop())))
+        args.interval = float(args.dataset.pop())
 
 if args.count is not None and not args.count > 0:
     parser.error('count must be positive')

--- a/ioztat
+++ b/ioztat
@@ -413,6 +413,7 @@ parser.add_argument('-z', dest='nonzero', action='store_true',
 
 args = parser.parse_args()
 
+# Handle [interval [count]]
 def is_positive_float(value):
     try:
         value = float(value)
@@ -428,16 +429,18 @@ if len(args.dataset) > 0 and is_positive_float(args.dataset[-1]):
         args.count = int(round(args.interval))
         args.interval = float(args.dataset.pop())
 
+# Past here interval and count are either None or non-zero
 if args.count is not None and not args.count > 0:
     parser.error('count must be positive')
 if args.interval is not None and not is_positive_float(args.interval):
     parser.error('interval must be positive')
 
-# If there's no interval but a count, default to one second
-if args.interval is None and args.count:
+# If there's a count but no interval, default to one second
+if args.count and not args.interval:
     args.interval = 1.0
 
-if args.count is None and args.interval is None:
+# If neither are specified, default to one iteration and one second
+if not (args.count or args.interval):
     args.count = 1
     args.interval = 1.0
 
@@ -455,6 +458,7 @@ else:
     # Accept either an exact match or one with an additional component
     dataset_pattern = re.compile("|".join(("\A" + re.escape(ds) + "(?:\Z|/[^/]+)" for ds in sorted(args.dataset))))
 
+# Set up our column configuration
 if args.scripted:
     column_separator = "\t"
     name_just = None
@@ -482,6 +486,7 @@ formatter.add_column('read',  width=field_width, format=format_bytes, just=num_j
 formatter.add_column('write', width=field_width, format=format_bytes, just=num_just)
 formatter.add_group('opsize', 2)
 
+# Configure a chain of iterators appropriate for our arguments
 diff_loop = filter_diff_iter(pools, dataset_pattern, args.nonzero)
 
 if args.interval:

--- a/ioztat.8
+++ b/ioztat.8
@@ -19,18 +19,25 @@
 .Op Fl T Ar u Ns | Ns d
 .Op Fl s Ar name Ns | Ns Ar operations Ns | Ns Ar reads Ns | Ns Ar writes Ns | Ns Ar throughput Ns | Ns Ar nread Ns | Ns Ar nwritten
 .Op Ar dataset ...
+.Op Ar interval Op Ar count
 .
 .Sh DESCRIPTION
 The
 .Nm
 utility displays logical I/O statistics for individual ZFS datasets.
-The first report is averaged over the system uptime, followed by reports averaged
-over the reporting
-.Ar interval ,
-one second by default.
-The initial summary may be suppressed with the
+The first report is averaged over the system uptime unless suppressed with
+.Fl y .
+If an
+.Ar interval
+is specified, this is followed by reports averaged over the reporting
+.Ar interval .
+If
 .Fl y
-option.
+or a
+.Ar count
+is specified,
+.Ar interval
+defaults to one second.
 .Pp
 Underlying device I/O depends on pool and dataset configuration.
 See
@@ -54,9 +61,14 @@ Display formatted byte sizes using decimal powers of 1000 instead of powers of 1
 Display
 .Ar count
 reports and exit.
-If no repeat
+This can also be specified after an
+.Ar interval
+at the end of the argument list.
+If
+.Ar interval
+is specified but not
 .Ar count
-is specified, the default is infinity.
+then it defaults to infinity, otherwise it defaults to one.
 .It Fl e
 Display exact values, without truncating dataset names (unless
 .Fl p
@@ -69,6 +81,8 @@ Display help text and exit.
 Pause
 .Ar interval
 seconds between reports.
+This can also be specified at the end of the argument list, optionally prior to a
+.Ar count .
 If no
 .Ar interval
 is specified the default is 1 second.
@@ -118,7 +132,7 @@ Omit datasets which have no activity.
 .Pp
 Display statistics for any mounted datasets within rpool/USERDATA which have activity.
 .Pp
-.Dl ioztat -zoTd -i5 -s operations
+.Dl ioztat -zoTd -s operations 5
 .Pp
 Display statistics for all mounted datasets with activity across five second intervals,
 ordered by total read and write operations, limited by available display and overwriting

--- a/ioztat.8
+++ b/ioztat.8
@@ -128,9 +128,9 @@ seconds.
 Omit datasets which have no activity.
 .El
 .Sh EXAMPLES
-.Dl ioztat -z rpool/USERDATA
+.Dl ioztat rpool/USERDATA 1
 .Pp
-Display statistics for any mounted datasets within rpool/USERDATA which have activity.
+Display per-second statistics for any mounted datasets within rpool/USERDATA.
 .Pp
 .Dl ioztat -zoTd -s operations 5
 .Pp
@@ -139,7 +139,7 @@ ordered by total read and write operations, limited by available display and ove
 prior reports in a manner similar to
 .Xr top 1 .
 .Pp
-.Dl ioztat -Heyc1
+.Dl ioztat -Hey
 .Pp
 Display a single one-second report for all mounted datasets, using a machine-readable
 format omitting headers, using tab-delimited fields, and providing exact values.


### PR DESCRIPTION
This adds `[interval [count]]` positional arguments, and changes the default iteration count to 1, bringing it in line with other iostat-alikes.

This involves a somewhat ugly hack with `argparse` - we add a dummy positional named `interval [count]` which, thanks to the prior `dataset` positional, will never be filled.  We then extract them from `dataset` manually after parsing.