### PR TITLE
Add unlink statistics behind an -x flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `-S` flag for including child dataset statistics in parents [#32]
 - `-T d|u` flag for adding a timestamp to each report [#25]
 - `-V`, `--version` flags [#13] [#14]
+- `-x` flag for extended statistics, including unlink counts under `-xx` [#33]
 - `interval` and `count` positional arguments [#31]
 
 ### Changed
@@ -26,6 +27,11 @@
 - `count` now defaults to 1 unless an `interval` is specified [#31]
 - `dataset` is now an optional argument [#20]
 - Binary (1024-based) formatting is now default, with new `-D` flag for decimal
+- Average I/O sizes are now hidden beyind `-x` flag by default to reduce clutter [#33]
+
+### Removed
+
+- `-b` flag. Binary mode is now the default to match other iostat tools.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ ssd                   0      0      0      0      0      0
 For the most part, `ioztat` behaves the same way that the system standard `iostat` tool does, with similar arguments.
 
 ````
-usage: ioztat [-c COUNT] [-D] [-e] [-H] [-h] [-I] [-i INTERVAL] [-N] [-n] [-o] [-P | -p] [-S]
-              [-s {name,operations,reads,writes,throughput,nread,nwritten}] [-T {u,d}] [-V] [-y] [-z]
+usage: ioztat [-c COUNT] [-D] [-e] [-H] [-h] [-I] [-i INTERVAL] [-N] [-n] [-o]
+              [-P | -p] [-S]
+              [-s {name,operations,reads,writes,throughput,nread,nwritten}]
+              [-T {u,d}] [-V] [-x] [-y] [-z]
               [dataset [dataset ...]] [interval [count]]
 
 iostat for ZFS datasets
@@ -41,12 +43,13 @@ positional arguments:
 
 optional arguments:
   -c COUNT              number of reports generated
-  -D                    display bytes in decimal powers of 1000 instead of 1024
+  -D                    display size in decimal powers of 1000 instead of 1024
   -e                    display exact values without truncation or scaling
   -H                    scripted mode, omit headers and tab-separate fields
   -h, --help            display this help message and exit
-  -I                    display totals since the last update rather than averaged per-second
-  -i INTERVAL           interval between reports (in seconds)
+  -I                    display totals since the last report rather than
+                        averaged per-second
+  -i INTERVAL           interval between reports in seconds
   -N                    display headers at most once
   -n                    omit child datasets when filtering
   -o                    overwrite old reports in terminal
@@ -55,8 +58,10 @@ optional arguments:
   -S                    include statistics for child datasets in parents
   -s {name,operations,reads,writes,throughput,nread,nwritten}
                         sort by the specified field
-  -T {u,d}              prefix each report with a Unix timestamp or formatted date
+  -T {u,d}              prefix reports with a Unix timestamp or formatted date
   -V, --version         display version number and exit
+  -x                    display extended statistics: once for average I/O
+                        size, twice for unlink queue
   -y                    omit the initial "summary" report
   -z                    omit datasets with zero activity
   ````

--- a/ioztat
+++ b/ioztat
@@ -58,6 +58,8 @@ class Dataset:
     nread = 0
     writes = 0
     nwritten = 0
+    nunlinks = 0
+    nunlinked = 0
     timestamp = 0
 
     def __init__(self, data=None):
@@ -67,6 +69,8 @@ class Dataset:
             self.nread = int(data['nread'])
             self.writes = int(data['writes'])
             self.nwritten = int(data['nwritten'])
+            self.nunlinks = int(data['nunlinks'])
+            self.nunlinked = int(data['nunlinked'])
             self.timestamp = int(data['timestamp'])
 
 
@@ -156,6 +160,8 @@ class DatasetDiff:
     nread = 0
     writes = 0
     nwritten = 0
+    nunlinks = 0
+    nunlinked = 0
 
     def __init__(self, name=''):
         self.name = name
@@ -166,6 +172,8 @@ class DatasetDiff:
         self.nread = new.nread - old.nread
         self.writes = new.writes - old.writes
         self.nwritten = new.nwritten - old.nwritten
+        self.nunlinks = new.nunlinks - old.nunlinks
+        self.nunlinked = new.nunlinked - old.nunlinked
         return self
 
     @property
@@ -190,10 +198,12 @@ class DatasetDiff:
             self.nread /= self.timediff
             self.writes /= self.timediff
             self.nwritten /= self.timediff
+            self.nunlinks /= self.timediff
+            self.nunlinked /= self.timediff
 
     def is_nonzero(self):
         """True if this DatasetDiff has any non-zero deltas"""
-        return self.reads or self.writes or self.nread or self.nwritten
+        return self.reads or self.writes or self.nread or self.nwritten or self.nunlinks or self.nunlinked
 
     def __add__(self, other):
         new = DatasetDiff(self.name)
@@ -202,6 +212,8 @@ class DatasetDiff:
         new.nread = self.nread + other.nread
         new.writes = self.writes + other.writes
         new.nwritten = self.nwritten + other.nwritten
+        new.nunlinks = self.nunlinks + other.nunlinks
+        new.nunlinked = self.nunlinked + other.nunlinked
         return new
 
 
@@ -545,6 +557,8 @@ def parse_args():
                         help='prefix each report with a Unix timestamp or formatted date')
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + PROGRAM_VERSION,
                         help='display version number and exit')
+    parser.add_argument('-x', dest='extended', action='count', default=0,
+                        help='display extended statistics (twice for more)')
     parser.add_argument('-y', dest='skip', action='store_const', default=0, const=1,
                         help='omit the initial "summary" report')
     parser.add_argument('-z', dest='nonzero', action='store_true',
@@ -630,9 +644,14 @@ def create_column_formatter(args):
     formatter.add_column('read',  width=field_width, format=format_bytes, just=num_just)
     formatter.add_column('write', width=field_width, format=format_bytes, just=num_just)
     formatter.add_group('throughput', 2)
-    formatter.add_column('read',  width=field_width, format=format_bytes, just=num_just)
-    formatter.add_column('write', width=field_width, format=format_bytes, just=num_just)
-    formatter.add_group('opsize', 2)
+    if args.extended > 0:
+        formatter.add_column('read',  width=field_width, format=format_bytes, just=num_just)
+        formatter.add_column('write', width=field_width, format=format_bytes, just=num_just)
+        formatter.add_group('opsize', 2)
+    if args.extended > 1:
+        formatter.add_column('queue',  width=field_width, format=format_iops, just=num_just)
+        formatter.add_column('done', width=field_width, format=format_iops, just=num_just)
+        formatter.add_group('unlinks', 2)
     return formatter
 
 
@@ -729,7 +748,7 @@ def main():
                 d.normalize_per_second()
 
             formatter.print_columns(name, d.reads, d.writes, d.nread, d.nwritten,
-                                    d.rareq_sz, d.wareq_sz)
+                                    d.rareq_sz, d.wareq_sz, d.nunlinks, d.nunlinked)
 
         if not (args.scripted or args.overwrite):
             formatter.print_divider()

--- a/ioztat
+++ b/ioztat
@@ -714,7 +714,7 @@ def main():
             diff.sort(**SORTS[args.sort])
 
         width, height = shutil.get_terminal_size()
-        avail_width = width - formatter.get_printed_width(1, 7)
+        avail_width = width - formatter.get_printed_width(1)
         max_name_width = max(max_name_width,
                              max((calc_name_width(d.name) for d in diff), default=10))
         name_width = max(10, min([avail_width, max_name_width]))

--- a/ioztat
+++ b/ioztat
@@ -546,7 +546,7 @@ def parse_args():
     parser.add_argument('-c', dest='count', type=int,
                         help='number of reports generated')
     parser.add_argument('-D', dest='decimal', action='store_true',
-                        help='display bytes in decimal powers of 1000 instead of 1024')
+                        help='display size in decimal powers of 1000 instead of 1024')
     parser.add_argument('-e', dest='exact', action='store_true',
                         help='display exact values without truncation or scaling')
     parser.add_argument('-H', dest='scripted', action='store_true',
@@ -554,9 +554,9 @@ def parse_args():
     parser.add_argument('-h', '--help', action='help',
                         help='display this help message and exit')
     parser.add_argument('-I', dest='perinterval', action='store_true',
-                        help='display totals since the last update rather than averaged per-second')
+                        help='display totals since the last report rather than averaged per-second')
     parser.add_argument('-i', dest='interval', type=float,
-                        help='interval between reports (in seconds)')
+                        help='interval between reports in seconds')
     parser.add_argument('-N', dest='headeronce', action='store_true',
                         help='display headers at most once')
     parser.add_argument('-n', dest='nonrecursive', action='store_true',
@@ -574,11 +574,12 @@ def parse_args():
                         choices=SORTS.keys(), metavar='{%s}' % ','.join(SORT_DISPLAY),
                         help='sort by the specified field')
     parser.add_argument('-T', dest='timestamp', choices=['u', 'd'],
-                        help='prefix each report with a Unix timestamp or formatted date')
+                        help='prefix reports with a Unix timestamp or formatted date')
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + PROGRAM_VERSION,
                         help='display version number and exit')
     parser.add_argument('-x', dest='extended', action='count', default=0,
-                        help='display extended statistics (twice for more)')
+                        help='display extended statistics: once for average I/O size, \
+                              twice for unlink queue')
     parser.add_argument('-y', dest='skip', action='store_const', default=0, const=1,
                         help='omit the initial "summary" report')
     parser.add_argument('-z', dest='nonzero', action='store_true',

--- a/ioztat
+++ b/ioztat
@@ -380,9 +380,14 @@ class ColumnFormatter:
         """Set the width of the column"""
         self.columns[self.column_index[key]].width = width
 
-    def get_printed_width(self, start, stop=None):
-        """Return the width of columns[start:stop]"""
-        return sum((c.width + len(self.column_separator) for c in self.columns[start:stop]))
+    def get_printed_width(self, exclude=()):
+        """
+        Return the printed width of columns and their separators, excluding the
+        keys in exclude.
+        """
+        return sum((c.width + len(self.column_separator)
+                   for c in self.columns
+                   if c.key not in exclude))
 
     def print_header(self):
         """Add headings and optionally group headings to the internal buffer"""
@@ -718,6 +723,7 @@ def main():
     args = parse_args()
     formatter = create_column_formatter(args)
 
+    stats_width = formatter.get_printed_width(exclude=('name'))
     calc_name_width = len if args.fullname else DatasetName.indent_len
     max_name_width = 0
     isatty = sys.stdout.isatty()
@@ -729,7 +735,7 @@ def main():
             diff.sort(**SORTS[args.sort])
 
         width, height = shutil.get_terminal_size()
-        avail_width = width - formatter.get_printed_width(1)
+        avail_width = width - stats_width
         max_name_width = max(max_name_width,
                              max((calc_name_width(d.name) for d in diff), default=10))
         name_width = max(10, min([avail_width, max_name_width]))

--- a/ioztat
+++ b/ioztat
@@ -305,14 +305,18 @@ class Column:
     Formats (translates raw value to string) and optionally justifies (adjusts
     the string to fit within a given width) a single column.
     """
-    def __init__(self, name, width=0, format=str, just=None):
-        self.name = name
+    def __init__(self, key, heading, width=0, format=str, just=None):
+        self.key = key
+        self.heading = heading
         self.width = width
         self.format = format
         self.just = just
 
-    def stringify(self, value):
-        return self.justify(str(self.format(value)))
+    def render(self, values):
+        return self.justify(str(self.format(values[self.key])))
+
+    def render_heading(self):
+        return self.justify(self.heading)
 
     def justify(self, string):
         return self.just(string, self.width) if self.just else string
@@ -326,14 +330,17 @@ class ColumnGroup:
     Width here is the size of separators not covered by the raw width of the
     spanned columns themselves.
     """
-    def __init__(self, name, columns, width=0, just=str.center):
-        self.name = name
+    def __init__(self, heading, columns, width=0, just=str.center):
+        self.heading = heading
         self.columns = columns
         self.width = width
         self.just = just
 
     def group_width(self):
         return self.width + sum((c.width for c in self.columns))
+
+    def render_heading(self):
+        return self.justify(self.heading)
 
     def justify(self, string):
         return self.just(string, self.group_width()) if self.just else string
@@ -345,15 +352,18 @@ class ColumnFormatter:
     """
     def __init__(self, column_separator='  ', row_separator='-', buffer=None):
         self.columns = []
+        self.column_index = {}
         self.groups = None
         self.column_separator = column_separator
         self.row_separator = row_separator
         self.buffer = buffer if buffer is not None else []
 
     def add_column(self, name, cls=Column, **args):
+        self.column_index[name] = len(self.columns)
         self.columns.append(cls(name, **args))
 
     def add_group(self, name='', colspan=1, just=str.center):
+        """Add a group heading that spans the previous colspan columns"""
         if self.groups is None:
             self.groups = ColumnFormatter(column_separator=self.column_separator,
                                           buffer=self.buffer)
@@ -361,25 +371,32 @@ class ColumnFormatter:
         self.groups.add_column(name, cls=ColumnGroup, columns=self.columns[-colspan:],
                                width=len(self.column_separator) * (colspan - 1), just=just)
 
-    def set_column_width(self, column, width):
-        self.columns[column].width = width
+    def add_row(self, **data):
+        """Add a row of data to be formatted into the internal buffer"""
+        formatted = (column.render(data) for column in self.columns)
+        self.print(self.column_separator.join(formatted))
+
+    def set_column_width(self, key, width):
+        """Set the width of the column"""
+        self.columns[self.column_index[key]].width = width
 
     def get_printed_width(self, start, stop=None):
         """Return the width of columns[start:stop]"""
         return sum((c.width + len(self.column_separator) for c in self.columns[start:stop]))
 
-    def print_columns(self, *columns):
-        formatted = (c.stringify(column) for (c, column) in zip(self.columns, columns))
-        self.print(self.column_separator.join(formatted))
-
     def print_header(self):
+        """Add headings and optionally group headings to the internal buffer"""
         if self.groups:
             self.groups.print_header()
 
-        formatted = (c.justify(c.name) for c in self.columns)
+        formatted = (column.render_heading() for column in self.columns)
         self.print(self.column_separator.join(formatted))
 
     def print_divider(self):
+        """
+        Add a line of column_separator in the space given to each column to the
+        internal buffer.
+        """
         self.print(
             self.column_separator.join(
                 [''.ljust(c.width, self.row_separator) for c in self.columns]))
@@ -393,9 +410,7 @@ class ColumnFormatter:
         self.buffer.append(string + end)
 
     def flush(self, lines=None):
-        """
-        Print the internal buffer, up to the optional lines limit.
-        """
+        """Print the internal buffer, up to the optional lines limit."""
         buffer = ''.join(self.buffer)
         if lines:
             buffer = "\n".join(buffer.split("\n", lines)[:lines])
@@ -629,28 +644,28 @@ def create_column_formatter(args):
         field_width = 11 if args.exact else 5
 
     if args.exact:
-        format_iops = round
+        format_num = round
         format_bytes = round
     else:
-        format_iops = NumberToHuman.formatter(length=field_width, decimal=True)
+        format_num = NumberToHuman.formatter(length=field_width, decimal=True)
         format_bytes = NumberToHuman.formatter(length=field_width, decimal=args.decimal)
 
     formatter = ColumnFormatter(column_separator=column_separator, row_separator='-')
-    formatter.add_column('dataset', just=name_just)
+    formatter.add_column('name', heading='dataset', just=name_just)
     formatter.add_group()
-    formatter.add_column('read',  width=field_width, format=format_iops, just=num_just)
-    formatter.add_column('write', width=field_width, format=format_iops, just=num_just)
+    formatter.add_column('reads', heading='read', width=field_width, format=format_num, just=num_just)
+    formatter.add_column('writes', heading='write', width=field_width, format=format_num, just=num_just)
     formatter.add_group('operations', 2)
-    formatter.add_column('read',  width=field_width, format=format_bytes, just=num_just)
-    formatter.add_column('write', width=field_width, format=format_bytes, just=num_just)
+    formatter.add_column('nread', heading='read', width=field_width, format=format_bytes, just=num_just)
+    formatter.add_column('nwritten', heading='write', width=field_width, format=format_bytes, just=num_just)
     formatter.add_group('throughput', 2)
     if args.extended > 0:
-        formatter.add_column('read',  width=field_width, format=format_bytes, just=num_just)
-        formatter.add_column('write', width=field_width, format=format_bytes, just=num_just)
+        formatter.add_column('rareq_sz', heading='read', width=field_width, format=format_bytes, just=num_just)
+        formatter.add_column('wareq_sz', heading='write', width=field_width, format=format_bytes, just=num_just)
         formatter.add_group('opsize', 2)
     if args.extended > 1:
-        formatter.add_column('queue',  width=field_width, format=format_iops, just=num_just)
-        formatter.add_column('done', width=field_width, format=format_iops, just=num_just)
+        formatter.add_column('nunlinks', heading='queue', width=field_width, format=format_num, just=num_just)
+        formatter.add_column('nunlinked', heading='done', width=field_width, format=format_num, just=num_just)
         formatter.add_group('unlinks', 2)
     return formatter
 
@@ -718,7 +733,7 @@ def main():
         max_name_width = max(max_name_width,
                              max((calc_name_width(d.name) for d in diff), default=10))
         name_width = max(10, min([avail_width, max_name_width]))
-        formatter.set_column_width(0, name_width)
+        formatter.set_column_width('name', name_width)
 
         if args.overwrite:
             # Clear the screen and move the cursor to the upper-left
@@ -747,8 +762,10 @@ def main():
             if not args.perinterval:
                 d.normalize_per_second()
 
-            formatter.print_columns(name, d.reads, d.writes, d.nread, d.nwritten,
-                                    d.rareq_sz, d.wareq_sz, d.nunlinks, d.nunlinked)
+            formatter.add_row(name=name, reads=d.reads, writes=d.writes,
+                              nread=d.nread, nwritten=d.nwritten,
+                              rareq_sz=d.rareq_sz, wareq_sz=d.wareq_sz,
+                              nunlinks=d.nunlinks, nunlinked=d.nunlinked)
 
         if not (args.scripted or args.overwrite):
             formatter.print_divider()

--- a/ioztat.8
+++ b/ioztat.8
@@ -13,7 +13,7 @@
 .Fl h | Fl -help
 .
 .Nm
-.Op Fl DeHINnoSyz
+.Op Fl DeHINnoSxyz
 .Op Fl c Ar count
 .Op Fl i Ar interval
 .Op Fl T Ar u Ns | Ns d
@@ -126,6 +126,11 @@ for a formatted date-time.
 Display the current version of
 .Nm
 and exit.
+.It Fl x
+Specified once, display an opsize group containing throughput divided by operations,
+giving the average byte size of each I/O.
+Specified twice, also display an unlinks section giving a count of the number of
+files and directories queued for deletion, and the number which have been deleted.
 .It Fl y
 Omit statistics since boot.
 This suppresses output for the first


### PR DESCRIPTION
Add the two other fields ZFS exposes: nunlinked, the number of files
unlinked from the filesystem, and nunlinks, which includes the number
that have been queued.

Add an -x flag for extended statistics.  Hide both opsize and nunlinks
by default to make for a clear display, with -x to add opsize and -xx to
add both that and unlink statistics.